### PR TITLE
prevent command injection in nmap script

### DIFF
--- a/hubot-scripts/nmap
+++ b/hubot-scripts/nmap
@@ -8,7 +8,7 @@
 
 function valid_ip()
 {
-    local  ip=$1
+    local  ip="$1"
     local  stat=1
 
     if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
@@ -23,6 +23,6 @@ function valid_ip()
     return $stat
 }
 
-if valid_ip $1; then /usr/bin/nmap -T4 -A -v $1;  else echo please use ip address only ; fi
+if valid_ip "$1"; then /usr/bin/nmap -T4 -A -v "$1";  else echo please use ip address only ; fi
 
 


### PR DESCRIPTION
When the script is executed with one argument that contains a whitespace, the validation function only looks at the first part of the argument (until to the whitespace character). The other parts of the argument are still passed to nmap as arguments.

```bash
./nmap.sh "127.0.0.1 evil stuff here"
```